### PR TITLE
Day6: Main pipeline fix

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -44,6 +44,14 @@ jobs:
       uses: trufflesecurity/trufflehog@main
       with:
         path: ./
-        base: main
+        base: ${{ github.event.repository.default_branch }}
         head: HEAD
         extra_args: --debug --only-verified
+      if: github.event_name == 'pull_request'
+
+    - name: Scan for secrets (full scan on push)
+      uses: trufflesecurity/trufflehog@main
+      with:
+        path: ./
+        extra_args: --debug --only-verified
+      if: github.event_name == 'push'


### PR DESCRIPTION
🔧 Fix TruffleHog Secret Scanning on Main Branch Merges
Problem
The security pipeline was failing when merging to main with the error:

BASE and HEAD commits are the same. TruffleHog won't scan anything.

Copy
This occurs because merge commits to main don't have a meaningful diff to scan.

Solution
Split TruffleHog scanning into two scenarios:

Pull Requests: Diff-based scanning (base vs head)

Push to main: Full repository scan

Changes
Modified .github/workflows/security.yml

Added conditional logic for different event types

Maintains security coverage while preventing pipeline failures

Testing
✅ PR scans work as before

✅ Main branch merges no longer fail

✅ Full repo scanning on direct pushes to main

Fixes the CI/CD pipeline reliability issue without compromising security scanning coverage.